### PR TITLE
Fix debug suppression when message is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.2
+* fix: prevent debug suppression from throwing when message is missing
+
 ## 0.4.1
 * fix: DDP message handling due to Meteor internal changes
 

--- a/client.js
+++ b/client.js
@@ -8,7 +8,7 @@ import { queueMethod, clearAll } from './lib/idb';
 
 const originalDebug = Meteor._debug;
 Meteor._debug = function (m, s) {
-  if (isSyncing() && s?.message.includes('MinimongoError: Duplicate _id') ) return; // suppress this debug error while syncing. it should only need suppression in the scenario where you invoke an insert with a preset _id which should be rare and you'd probably want to use an upsert instead
+  if (isSyncing() && s?.message?.includes('MinimongoError: Duplicate _id') ) return; // suppress this debug error while syncing. it should only need suppression in the scenario where you invoke an insert with a preset _id which should be rare and you'd probably want to use an upsert instead
   return originalDebug.call(this, m, s);
 }
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'jam:offline',
-  version: '0.4.1',
+  version: '0.4.2',
   summary: 'An easy way to give your Meteor app offline capabilities and make it feel instant',
   git: 'https://github.com/jamauro/offline',
   documentation: 'README.md'

--- a/tests.js
+++ b/tests.js
@@ -189,6 +189,27 @@ if (Meteor.isServer) {
 
 // Client only tests
 if (Meteor.isClient) {
+  const { syncing } = require('./lib/sync');
+
+  Tinytest.add('debug suppression handles missing message', (test) => {
+    const wasSyncing = syncing.get();
+    const originalLog = console.log;
+    let didThrow = false;
+
+    try {
+      console.log = () => {};
+      syncing.set(true);
+      Meteor._debug('debug without message', {});
+    } catch (error) {
+      didThrow = true;
+    } finally {
+      console.log = originalLog;
+      syncing.set(wasSyncing);
+    }
+
+    test.isFalse(didThrow);
+  });
+
   Tinytest.addAsync('keep', async (test) => {
 
     const things = offlineCollections.get('things')


### PR DESCRIPTION
Fixes #27

## Summary
- Guard the debug suppression check when the debug payload has no `message` field.
- Add a Tinytest regression for `Meteor._debug` while syncing with a missing message.
- Bump the package to `0.4.2` and add the changelog entry.
